### PR TITLE
detect platform with `uname -s`

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  platform=linux64
-else
-  platform=macos
-fi
+case "$(uname -s)" in
+  "Linux")
+    platform=linux64
+    ;;
+  "Darwin")
+    platform=macos
+    ;;
+esac
 
 download_path() {
   local version=$1


### PR DESCRIPTION
I found that not all linux distribution returns `linux-gnu` for envvar `$OSTYPE`.
For example, `$OSTYPE` is `linux` in openSUSE Leap 15.2 as below.

![image](https://user-images.githubusercontent.com/15703757/86732671-8c885500-c06b-11ea-91fc-84c24b84470f.png)

This change detects platform with `uname -s ` instead of `$OSTYPE` to cover all linux distributions.
