### PR TITLE
Install from ref

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/utils.sh"
+
+download_neovim() {
+  local install_type=$1
+  local version=$2
+  local download_path=$3
+
+  if [ "$TMPDIR" = "" ]; then
+    local tmp_download_dir=$(mktemp -d -t neovim_build_XXXXXX)
+  else
+    local tmp_download_dir=$TMPDIR
+  fi
+
+  echo "$tmp_download_dir"
+  local archive_path=$(download_path $version $tmp_download_dir)
+  download_version $version $archive_path
+
+    # running this in subshell
+    # we don't want to disturb current working dir
+    (
+    if ! type "tar" &>/dev/null; then
+      echo "ERROR: tar not found"
+      exit 1
+    fi
+
+    tar zxf $archive_path -C $download_path --strip-components=1 || exit 1
+  )
+}
+
+download_neovim "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_DOWNLOAD_PATH"

--- a/bin/download
+++ b/bin/download
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 
+# shellcheck source=bin/utils.sh
 source "$(dirname "$0")/utils.sh"
 
 download_neovim() {
   local install_type=$1
   local version=$2
   local download_path=$3
+  local tmp_download_dir
+  local archive_path
 
   if [ "$TMPDIR" = "" ]; then
-    local tmp_download_dir=$(mktemp -d -t neovim_build_XXXXXX)
+    tmp_download_dir=$(mktemp -d -t neovim_build_XXXXXX)
   else
-    local tmp_download_dir=$TMPDIR
+    tmp_download_dir=$TMPDIR
   fi
 
-  echo "$tmp_download_dir"
-  local archive_path=$(download_path $version $tmp_download_dir)
-  download_version $version $archive_path
+  archive_path=$(download_path "$version" "$tmp_download_dir")
+  download_version "$install_type" "$version" "$archive_path"
 
     # running this in subshell
     # we don't want to disturb current working dir
@@ -25,7 +27,7 @@ download_neovim() {
       exit 1
     fi
 
-    tar zxf $archive_path -C $download_path --strip-components=1 || exit 1
+    tar zxf "$archive_path" -C "$download_path" --strip-components=1 || exit 1
   )
 }
 

--- a/bin/install
+++ b/bin/install
@@ -1,39 +1,28 @@
 #!/usr/bin/env bash
 
-source "$(dirname "$0")/utils.sh"
-
 install_neovim() {
-  local install_type=$1
-  local version=$2
-  local install_path=$3
-  local concurrency=$3
+  local build_path
 
-  if [ "$install_type" != "version" ]; then
-    echoerr "Cannot install specific ref from source, sorry."
-    echoerr "For a list of available versions, see \`asdf list-all neovim\`."
-    exit 1
-  fi
+  if [ "$ASDF_INSTALL_TYPE" = "version" ]; then
+    build_path="$ASDF_DOWNLOAD_PATH"
 
-  if [ "$TMPDIR" = "" ]; then
-    local tmp_download_dir=$(mktemp -d -t neovim_build_XXXXXX)
+    mv -f "$build_path"/** "" 
   else
-    local tmp_download_dir=$TMPDIR
+    (
+      cd "$ASDF_DOWNLOAD_PATH"
+
+      if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        make CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH="
+      else
+        make CMAKE_BUILD_TYPE=Release \
+             CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH="
+      fi
+
+      make DESTDIR="${ASDF_INSTALL_PATH}" install
+    )
   fi
 
-  echo "$tmp_download_dir"
-  local archive_path=$(download_path $version $tmp_download_dir)
-  download_version $version $archive_path
-
-    # running this in subshell
-    # we don't want to disturb current working dir
-    (
-    if ! type "tar" &>/dev/null; then
-      echo "ERROR: tar not found"
-      exit 1
-    fi
-
-    tar zxf $archive_path -C $install_path --strip-components=1 || exit 1
-  )
+  rm -rf "$ASDF_DOWNLOAD_PATH"
 }
 
-install_neovim "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH" "$ASDF_CONCURRENCY"
+install_neovim

--- a/bin/install
+++ b/bin/install
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 
 install_neovim() {
-  local build_path
+  local install_type="$1"
+  local download_path="$2"
+  local install_path="$3"
 
-  if [ "$ASDF_INSTALL_TYPE" = "version" ]; then
-    build_path="$ASDF_DOWNLOAD_PATH"
-
-    mv -f "$build_path"/** "" 
+  if [ "$install_type" = "version" ]; then
+    # move the prebuilt artifact to the install path
+    mv -f "$download_path"/** "$install_path" 
   else
     (
-      cd "$ASDF_DOWNLOAD_PATH"
+      cd "$download_path" || exit 1
 
+      # compile neovim with some extra flags
+      # these flags add the install path to the rtp, allowing us to package up
+      # the runtime instead of installing it globally.
+      # I sourced these flags for the neovim/bot-ci repo, where the prebuilt
+      # artifacts are compiled.
       if [[ "$OSTYPE" == "linux-gnu" ]]; then
         make CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH="
       else
@@ -18,11 +24,13 @@ install_neovim() {
              CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH="
       fi
 
-      make DESTDIR="${ASDF_INSTALL_PATH}" install
+      make DESTDIR="${install_path}" install
     )
   fi
 
-  rm -rf "$ASDF_DOWNLOAD_PATH"
+  # delete the download path with -f. I noticed there are some files that it
+  # will prompt you to delete. This avoids that.
+  rm -rf "$download_path"
 }
 
-install_neovim
+install_neovim "$ASDF_INSTALL_TYPE" "$ASDF_DOWNLOAD_PATH" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -16,4 +16,5 @@ git ls-remote --heads --tags https://github.com/neovim/neovim.git \
   | sort_versions
 )
 
+# shellcheck disable=SC2086
 echo $list_of_versions

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -14,36 +14,34 @@ download_path() {
 }
 
 download_version() {
-  local version=$1
-  local download_path=$2
-  local download_url=$(download_url $version)
+  local install_type=$1
+  local version=$2
+  local download_path=$3
+  local download_url
 
-  rm $download_path
+  download_url=$(download_url "$install_type" "$version")
 
-  echo "curl -Lo $download_path -C - $download_url"
-  curl -Lo $download_path -C - $download_url || exit 1
+  rm "$download_path"
+
+  echo "==> curl -Lo $download_path -C - $download_url"
+  curl -Lo "$download_path" -C - "$download_url" || exit 1
 }
 
 download_url() {
+  local install_type=$1
+  local version_arg=$2
+  local version
+  if [[ "${version_arg}" =~ ^[0-9]+\.* ]] ; then
+    version="v$2"
+  else
+    version="$2"
+  fi
+
   if [ "$install_type" = "version" ]; then
-    local version_arg="$1"
-    if [[ "$version_arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      local version="v$1"
-    else
-      local version="$1"
-    fi
     echo "https://github.com/neovim/neovim/releases/download/${version}/nvim-${platform}.tar.gz"
   else
-    local version
-    version=$1
-
-    if [[ "${version}" =~ ^[0-9]+\.* ]] ; then
-      # if version is a release number, prepend v
-      echo "https://github.com/neovim/neovim/archive/v${version}.tar.gz"
-    else
-      # otherwise it can be a branch name or commit sha
-      echo "https://github.com/neovim/neovim/archive/${version}.tar.gz"
-    fi
+    # otherwise it can be a branch name or commit sha
+    echo "https://github.com/neovim/neovim/archive/${version}.tar.gz"
   fi
 
   return

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -13,21 +13,38 @@ download_path() {
   echo "$tmp_download_dir/neovim-${version}.tar.gz"
 }
 
-download_url() {
-  local version_arg="$1"
-  if [[ "$version_arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    local version="v$1"
-  else
-    local version="$1"
-  fi
-  echo "https://github.com/neovim/neovim/releases/download/${version}/nvim-${platform}.tar.gz"
-}
-
 download_version() {
   local version=$1
   local download_path=$2
   local download_url=$(download_url $version)
 
+  rm $download_path
+
   echo "curl -Lo $download_path -C - $download_url"
-  curl -Lo $download_path -C - $download_url
+  curl -Lo $download_path -C - $download_url || exit 1
+}
+
+download_url() {
+  if [ "$install_type" = "version" ]; then
+    local version_arg="$1"
+    if [[ "$version_arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      local version="v$1"
+    else
+      local version="$1"
+    fi
+    echo "https://github.com/neovim/neovim/releases/download/${version}/nvim-${platform}.tar.gz"
+  else
+    local version
+    version=$1
+
+    if [[ "${version}" =~ ^[0-9]+\.* ]] ; then
+      # if version is a release number, prepend v
+      echo "https://github.com/neovim/neovim/archive/v${version}.tar.gz"
+    else
+      # otherwise it can be a branch name or commit sha
+      echo "https://github.com/neovim/neovim/archive/${version}.tar.gz"
+    fi
+  fi
+
+  return
 }


### PR DESCRIPTION
This allows you to install from a ref, for example `asdf install neovim ref:master` and it will compile the master branch from source.

Closes #7 