### PR TITLE
Make plugin backwards-compatible with asdf v0.7

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,6 +24,25 @@ jobs:
           command: nvim --version
         env:
           GITHUB_API_TOKEN: ${{ github.token }}
+  plugin_test_v0_7:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Setup asdf v0.7.8
+        uses: asdf-vm/actions/setup@v1
+        with:
+          asdf_branch: v0.7.8
+      - name: Test plugin
+        uses: asdf-vm/actions/plugin-test@v1
+        with:
+          command: nvim --version
+        env:
+          GITHUB_API_TOKEN: ${{ github.token }}
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/bin/download
+++ b/bin/download
@@ -3,32 +3,4 @@
 # shellcheck source=bin/utils.sh
 source "$(dirname "$0")/utils.sh"
 
-download_neovim() {
-  local install_type=$1
-  local version=$2
-  local download_path=$3
-  local tmp_download_dir
-  local archive_path
-
-  if [ "$TMPDIR" = "" ]; then
-    tmp_download_dir=$(mktemp -d -t neovim_build_XXXXXX)
-  else
-    tmp_download_dir=$TMPDIR
-  fi
-
-  archive_path=$(download_path "$version" "$tmp_download_dir")
-  download_version "$install_type" "$version" "$archive_path"
-
-  # running this in subshell
-  # we don't want to disturb current working dir
-  (
-    if ! type "tar" &>/dev/null; then
-      echo "ERROR: tar not found"
-      exit 1
-    fi
-
-    tar zxf "$archive_path" -C "$download_path" --strip-components=1 || exit 1
-  )
-}
-
 download_neovim "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_DOWNLOAD_PATH"

--- a/bin/install
+++ b/bin/install
@@ -5,6 +5,17 @@ install_neovim() {
   local download_path="$2"
   local install_path="$3"
 
+  if [ -z "$download_path" ]; then
+    #: We're on asdf 0.7.*
+    ASDF_DOWNLOAD_PATH="/tmp/asdf-neovim-$install_type-$ASDF_INSTALL_VERSION"
+    $download_path=$ASDF_DOWNLOAD_PATH
+    if [ -e $download_path ]; then
+      rm -rf $download_path
+    fi
+    mkdir $download_path
+    source "$(dirname "$0")/download"
+  fi
+
   if [ "$install_type" = "version" ]; then
     # move the prebuilt artifact to the install path
     mv -f "$download_path"/** "$install_path"

--- a/bin/install
+++ b/bin/install
@@ -11,8 +11,8 @@ install_neovim() {
   if [ -z "$download_path" ]; then
     #: We're on asdf 0.7.*
     ASDF_DOWNLOAD_PATH="/tmp/asdf-neovim-$install_type-$ASDF_INSTALL_VERSION"
+    download_path=$(mktemp -d -t "$ASDF_DOWNLOAD_PATH")
     download_neovim "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_DOWNLOAD_PATH"
-    download_path=$ASDF_DOWNLOAD_PATH
   fi
 
   if [ "$install_type" = "version" ]; then

--- a/bin/install
+++ b/bin/install
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# shellcheck source=bin/utils.sh
+source "$(dirname "$0")/utils.sh"
+
 install_neovim() {
   local install_type="$1"
   local download_path="$2"
@@ -8,12 +11,8 @@ install_neovim() {
   if [ -z "$download_path" ]; then
     #: We're on asdf 0.7.*
     ASDF_DOWNLOAD_PATH="/tmp/asdf-neovim-$install_type-$ASDF_INSTALL_VERSION"
-    $download_path=$ASDF_DOWNLOAD_PATH
-    if [ -e $download_path ]; then
-      rm -rf $download_path
-    fi
-    mkdir $download_path
-    source "$(dirname "$0")/download"
+    download_neovim "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_DOWNLOAD_PATH"
+    download_path=$ASDF_DOWNLOAD_PATH
   fi
 
   if [ "$install_type" = "version" ]; then

--- a/bin/install
+++ b/bin/install
@@ -10,8 +10,8 @@ install_neovim() {
 
   if [ -z "$download_path" ]; then
     #: We're on asdf 0.7.*
-    ASDF_DOWNLOAD_PATH="/tmp/asdf-neovim-$install_type-$ASDF_INSTALL_VERSION"
-    download_path=$(mktemp -d -t "$ASDF_DOWNLOAD_PATH")
+    download_path=$(mktemp -d -t "asdf-neovim-$install_type-$ASDF_INSTALL_VERSION-XXXX")
+    ASDF_DOWNLOAD_PATH="$download_path"
     download_neovim "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_DOWNLOAD_PATH"
   fi
 

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -49,3 +49,31 @@ download_url() {
 
   return
 }
+
+download_neovim() {
+  local install_type=$1
+  local version=$2
+  local download_path=$3
+  local tmp_download_dir
+  local archive_path
+
+  if [ "$TMPDIR" = "" ]; then
+    tmp_download_dir=$(mktemp -d -t neovim_build_XXXXXX)
+  else
+    tmp_download_dir=$TMPDIR
+  fi
+
+  archive_path=$(download_path "$version" "$tmp_download_dir")
+  download_version "$install_type" "$version" "$archive_path"
+
+  # running this in subshell
+  # we don't want to disturb current working dir
+  (
+    if ! type "tar" &>/dev/null; then
+      echo "ERROR: tar not found"
+      exit 1
+    fi
+
+    tar zxf "$archive_path" -C "$download_path" --strip-components=1 || exit 1
+  )
+}


### PR DESCRIPTION
This PR fixes #11 and make the plugin backwards-compatible with asdf `v0.7.*` by falling back to setting `$ASDF_DOWNLOAD_PATH` and manually invoking `bin/download` from `bin/install`