### PR TITLE
Fix \d does not work with POSIX (bash) regex

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -34,7 +34,7 @@ download_url() {
   local install_type=$1
   local version_arg=$2
   local version
-  if [[ "${version_arg}" =~ ^\d+\.\d+\.\d+ ]]; then
+  if [[ "${version_arg}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
     version="v$2"
   else
     version="$2"


### PR DESCRIPTION
Hi, thanks for the plugin. I found that I was not able to download Neovim (using `asdf install neovim 0.7.2`) after upgrading to the latest version of this plugin. I tracked down the issue to this line
https://github.com/richin13/asdf-neovim/blob/5b19ea5071650f1eca2e8fa0feca5006986b99ed/bin/utils.sh#L37-L41

It seems that `\d` is not supported in Bash which leads to unmatch regular expression, and version value `0.7.2` is not preprended with `v`, and the plugin is trying to download Neovim release from `https://github.com/neovim/neovim/releases/download/0.7.2/nvim-linux64.tar.gz` which is incorrect URL (`v` is missing before `0.7.2`).

I am proposing a fix for the issue in this PR. Thank you.
