### PR TITLE
Fix rm no file error message

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -24,7 +24,7 @@ download_version() {
 
   download_url=$(download_url "$install_type" "$version")
 
-  rm "$download_path"
+  [ -f $download_path ] && rm "$download_path"
 
   echo "==> curl -Lo $download_path -C - $download_url"
   curl -Lo "$download_path" -C - "$download_url" || exit 1


### PR DESCRIPTION
Good day, thank you very much for this plugin!

Today I was going to install the newer version o neovim and realized that an error message was being printed in the screen:

![image](https://user-images.githubusercontent.com/60318892/216624436-78ebb8ae-759b-4910-8029-869844b4764b.png)

```sh
$ asdf install neovim 0.8.3
rm: cannot remove '/tmp/neovim_build_omAEeh/neovim-0.8.3.tar.gz': No such file or directory
```

So I decided to check the code, and apparently it is the `download_version()` function in the **utils.sh** file that is just doing a normal rm command. To avoid this message, I think there are two ways:

- Check if the file exists before attempting to remove it
- Force the rm command (`-f` flag)

In my propostal I did the first one, a check with the `-f` flag for the test: `[ -f ... ] && rm ...`.

From `man test`:

```
-f FILE
       FILE exists and is a regular file
```