### PR TITLE
fix: macos is now platform specific

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -31,25 +31,21 @@ download_url() {
     version="$2"
   fi
 
-  case "$(uname -s)" in
-    "Linux")
-      platform=linux64
-      ;;
-    "Darwin")
-      if [ "$version" = "nightly" ]; then
-        case "$(uname -p)" in
-          "arm")
-            platform=macos-arm64
-            ;;
-          *)
-            platform=macos-x86_64
-            ;;
-        esac
-      else
-        platform=macos
-      fi
-      ;;
-  esac
+	case "$(uname -s)" in
+	"Linux")
+		platform=linux64
+		;;
+	"Darwin")
+		case "$(uname -p)" in
+		"arm")
+			platform=macos-arm64
+			;;
+		*)
+			platform=macos-x86_64
+			;;
+		esac
+		;;
+	esac
 
   if [ "$install_type" = "version" ]; then
     echo "https://github.com/neovim/neovim/releases/download/${version}/nvim-${platform}.tar.gz"

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -36,14 +36,23 @@ download_url() {
 		platform=linux64
 		;;
 	"Darwin")
-		case "$(uname -p)" in
-		"arm")
-			platform=macos-arm64
-			;;
-		*)
-			platform=macos-x86_64
-			;;
-		esac
+		# Check version is less than v0.10.0 - if it is, use the old platform name
+		# using IFS to split the version number into an array
+		IFS='.' read -r -a version_array <<<"${version#v}"
+
+		# version_array[0] is the major version and version_array[1] is the minor version
+		if ((version_array[0] == 0 && version_array[1] < 10)); then
+			platform=macos
+		else
+			case "$(uname -p)" in
+			"arm")
+				platform=macos-arm64
+				;;
+			*)
+				platform=macos-x86_64
+				;;
+			esac
+		fi
 		;;
 	esac
 

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -41,7 +41,7 @@ download_url() {
 		IFS='.' read -r -a version_array <<<"${version#v}"
 
 		# version_array[0] is the major version and version_array[1] is the minor version
-		if ((version_array[0] == 0 && version_array[1] < 10)); then
+		if ((version_array[0] == 0 && version_array[1] < 10)) && [[ ! $version =~ ^stable|nightly$ ]]; then
 			platform=macos
 		else
 			case "$(uname -p)" in


### PR DESCRIPTION
it looks like with the latest 0.10.0 release, neovim is publishing macos-arm or macos-x86_64 versions only

relates to issue #21 